### PR TITLE
Add missing getMerchantId and setMerchantId in Gateway.php

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -26,6 +26,16 @@ class Gateway extends AbstractGateway
             'testMode' => false,
         );
     }
+    
+    public function getMerchantId()
+    {
+        return $this->getParameter('merchantId');
+    }
+
+    public function setMerchantId($value)
+    {
+        return $this->setParameter('merchantId', $value);
+    }
 
     public function getCertificate()
     {


### PR DESCRIPTION
Hello,

When you try to get default parameters for this gateway, it return an array of 3 things : 

        return array(
            'merchantId' => '',
            'certificate' => '',
            'testMode' => false,
        );

But, when you call : 

        $gateway->initialize([
            'merchantId' => $merchantId,
            'certificate' => $certificate,
            'testMode' => $testMode,
        ]);

and you debug the gateway variable, you see that the merchantId is empty whereas the certificate is correctly filled.

The reason is that the Gateway.php file have methods to set and get certificate, but not the merchantId. You can add the merchant Id by proving it as options when you call the completePurchase method for example, but it sound more logical to initialise it when you initialize the gateway, like the certificate. And for that, you need the get and set Method in the Gateway class.

Here is the PR that fix this

Best regards,