### PR TITLE
Fix error with latest omnipay version

### DIFF
--- a/src/Message/CompletePurchaseRequest.php
+++ b/src/Message/CompletePurchaseRequest.php
@@ -16,4 +16,9 @@ class CompletePurchaseRequest extends AbstractRequest
     {
         return $this->response = new CompletePurchaseResponse($this, $data);
     }
+    
+    public function getEndpoint()
+    {
+        return 'https://paiement.systempay.fr/vads-payment/';
+    }
 }


### PR DESCRIPTION
I'm not sure when it appears, but I know that I already used your module in a previous project with success, and the same code with another project no longer work, so I suppose that there were an update in omnipay itself.

Here is the error I get when I try to call the completePurchase() method : 

> Symfony\Component\Debug\Exception\FatalErrorException: Class Omnipay\SystemPay\Message\CompletePurchaseRequest contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Omnipay\SystemPay\Message\AbstractRequest::getEndpoint) in /httpdocs/vendor/hounddd/omnipay-systempay/src/Message/CompletePurchaseRequest.php:10

So, as suggested by the debug, I implemented the getEndPoint() method in this PR for the CompletePurchaseRequest class and everything works again.