### PR TITLE
Complete subscription support

### DIFF
--- a/src/Message/CompletePurchaseResponse.php
+++ b/src/Message/CompletePurchaseResponse.php
@@ -49,7 +49,7 @@ class CompletePurchaseResponse extends AbstractResponse
 
     public function getTransactionId()
     {
-        return isset($this->data['vads_trans_id']) ? $this->data['vads_trans_id'] : null;
+        return isset($this->data['vads_order_id']) ? (int) $this->data['vads_order_id'] : null;
     }
 
     public function getUuid()

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -27,6 +27,7 @@ class PurchaseRequest extends AbstractRequest
         $data['vads_site_id'] = $this->getMerchantId();
         $data['vads_ctx_mode'] = $this->getTestMode() ? 'TEST' : 'PRODUCTION';
         $data['vads_trans_id'] = str_pad($this->getTransactionId(), 6, '0', STR_PAD_LEFT);
+        $data['vads_order_id'] = str_pad($this->getTransactionId(), 6, '0', STR_PAD_LEFT);
         $data['vads_trans_date'] = $this->getTransactionDate() ? $this->getTransactionDate() : date('YmdHis');
         $data['vads_amount'] = $this->getAmountInteger();
         $data['vads_currency'] = $this->getCurrencyNumeric();
@@ -40,7 +41,6 @@ class PurchaseRequest extends AbstractRequest
         $data['vads_url_cancel'] = $this->getCancelUrl();
         $data['vads_url_error'] = $this->getErrorUrl();
         $data['vads_url_refused'] = $this->getRefusedUrl();
-        $data['vads_order_id'] = $this->getOrderId();
         $data['vads_payment_cards'] = $this->getPaymentCards();
 
         if (null !== $this->getNotifyUrl()) {

--- a/src/Message/PurchaseResponse.php
+++ b/src/Message/PurchaseResponse.php
@@ -41,4 +41,9 @@ class PurchaseResponse extends AbstractResponse implements RedirectResponseInter
     {
         return $this->data;
     }
+
+    public function getTransactionReference()
+    {      
+        return isset($this->data['vads_subscription']) ? (int) $this->data['vads_subscription'] : null;
+    }
 }


### PR DESCRIPTION
This PR make other payments in a subscription reliable.

Explanations: 

- When  `vads_trans_id` is sent in the request, it's also return its value in the IPN
- But in a subscription context, on others payments, the `vads_trans_id` is replaced by a generated transaction ID

My approach is to populate the `vads_order_id` field with the same value as `vads_trans_id` and use it as internal transaction id. The value of this field is kept over all future payments.

In the meantime, we add a `getTransactionReference()` with the value of `vads_subscription_id` which allows to attribute new transaction to the correct subscription.

@damsfx does it make sens?

I have a doubt about the duplicate value in order_id and trans_id.